### PR TITLE
chore: update gitignore and fix test formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .pnp
 .pnp.js
 .yarn/install-state.gz
+.pnpm-store/
 
 # Testing
 coverage/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.pnpm-store/
 # Keep environment variables out of version control
 .env
 

--- a/backend/src/protocols/protocol-adapter.registry.spec.ts
+++ b/backend/src/protocols/protocol-adapter.registry.spec.ts
@@ -222,13 +222,12 @@ describe('ProtocolAdapterRegistry', () => {
         100,
       );
       let timeoutId: NodeJS.Timeout;
-      slowAdapter.getPositions = jest
-        .fn()
-        .mockImplementation(
-          () => new Promise((resolve) => {
+      slowAdapter.getPositions = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
             timeoutId = setTimeout(resolve, 5000);
           }),
-        );
+      );
 
       registry.register(slowAdapter);
 
@@ -237,7 +236,7 @@ describe('ProtocolAdapterRegistry', () => {
       });
 
       expect(positions.size).toBe(0);
-      
+
       // Clean up the timeout
       if (timeoutId) {
         clearTimeout(timeoutId);

--- a/backend/src/websocket/websocket.service.spec.ts
+++ b/backend/src/websocket/websocket.service.spec.ts
@@ -61,7 +61,7 @@ describe('WebsocketService', () => {
 
       expect(subscribeSpy).toHaveBeenCalled();
       expect(priceUpdateSpy).toHaveBeenCalled();
-      
+
       service.disconnect(); // Clean up the interval
     });
   });
@@ -79,7 +79,7 @@ describe('WebsocketService', () => {
       service.broadcastPriceUpdate(priceUpdate);
 
       expect(mockServer.to).toHaveBeenCalledWith('prices');
-      
+
       service.disconnect(); // Clean up the interval
     });
 
@@ -94,7 +94,7 @@ describe('WebsocketService', () => {
       service.broadcastPriceUpdate(priceUpdates);
 
       expect(mockServer.to).toHaveBeenCalledWith('prices');
-      
+
       service.disconnect(); // Clean up the interval
     });
 
@@ -127,7 +127,7 @@ describe('WebsocketService', () => {
       service.broadcastWalletUpdate(walletUpdate);
 
       expect(mockServer.to).toHaveBeenCalledWith('wallet:test-wallet');
-      
+
       service.disconnect(); // Clean up the interval
     });
   });
@@ -144,7 +144,7 @@ describe('WebsocketService', () => {
       service.broadcastPositionUpdate(positionData);
 
       expect(mockServer.to).toHaveBeenCalledWith('wallet:test-wallet');
-      
+
       service.disconnect(); // Clean up the interval
     });
   });


### PR DESCRIPTION
## Summary
- Added `.pnpm-store/` to gitignore files to properly exclude pnpm local cache directory
- Fixed minor formatting issues in test files (whitespace cleanup)

## Changes
- Updated `.gitignore` and `backend/.gitignore` to ignore `.pnpm-store/`
- Cleaned up formatting in `protocol-adapter.registry.spec.ts` and `websocket.service.spec.ts`

## Test plan
- [x] All backend tests pass (`pnpm run test`)
- [x] Linting passes with no errors (`pnpm run lint`)
- [x] Changes are minimal and safe

🤖 Generated with [Claude Code](https://claude.ai/code)