### PR TITLE
chore: temporarily disable slow CI jobs to speed up development

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,66 +12,68 @@ env:
 
 jobs:
   # Detect if Dockerfile changed
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    outputs:
-      dockerfile: ${{ steps.filter.outputs.dockerfile }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            dockerfile:
-              - '.github/docker/playwright-e2e.Dockerfile'
-              - '.github/workflows/pr-checks.yml'
+  # TEMPORARILY DISABLED - Slow CI job
+  # changes:
+  #   name: Detect Changes
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     dockerfile: ${{ steps.filter.outputs.dockerfile }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dorny/paths-filter@v3
+  #       id: filter
+  #       with:
+  #         filters: |
+  #           dockerfile:
+  #             - '.github/docker/playwright-e2e.Dockerfile'
+  #             - '.github/workflows/pr-checks.yml'
 
   # Build Docker image if Dockerfile changed
-  build-e2e-image:
-    name: Build E2E Docker Image
-    runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.dockerfile == 'true'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=raw,value=latest
-            type=raw,value=playwright-1.55.0
-            
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: .github/docker/playwright-e2e.Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
-          platforms: linux/amd64
+  # TEMPORARILY DISABLED - Slow CI job
+  # build-e2e-image:
+  #   name: Build E2E Docker Image
+  #   runs-on: ubuntu-latest
+  #   needs: changes
+  #   if: needs.changes.outputs.dockerfile == 'true'
+  #   permissions:
+  #     contents: read
+  #     packages: write
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+  #       
+  #     - name: Log in to GitHub Container Registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #         
+  #     - name: Extract metadata
+  #       id: meta
+  #       uses: docker/metadata-action@v5
+  #       with:
+  #         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+  #         tags: |
+  #           type=ref,event=branch
+  #           type=ref,event=pr
+  #           type=raw,value=latest
+  #           type=raw,value=playwright-1.55.0
+  #           
+  #     - name: Build and push Docker image
+  #       uses: docker/build-push-action@v5
+  #       with:
+  #         context: .
+  #         file: .github/docker/playwright-e2e.Dockerfile
+  #         push: true
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
+  #         cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+  #         cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+  #         platforms: linux/amd64
 
   frontend-checks:
     name: Frontend Tests & Linting
@@ -196,76 +198,77 @@ jobs:
         working-directory: ./backend
         run: pnpm run build
 
-  e2e-tests:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    # Wait for image build if Dockerfile changed, otherwise run immediately
-    needs: [changes, build-e2e-image]
-    if: always() && !cancelled() && !failure()
-    container:
-      # Use our custom Docker image with pre-installed Playwright and pnpm
-      # This saves ~45-60 seconds by not having to download and install dependencies
-      image: ghcr.io/${{ github.repository_owner }}/solfolio-e2e:${{ needs.changes.outputs.dockerfile == 'true' && github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-          
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-          
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.STORE_PATH }}
-            ~/.cache
-            frontend/node_modules
-          key: ${{ runner.os }}-pnpm-store-e2e-${{ hashFiles('frontend/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-e2e-
-            
-      - name: Setup Next.js build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            frontend/.next/cache
-          key: ${{ runner.os }}-nextjs-e2e-${{ hashFiles('frontend/**/package-lock.json', 'frontend/**/pnpm-lock.yaml', 'frontend/**/yarn.lock') }}-${{ hashFiles('frontend/**.[jt]s', 'frontend/**.[jt]sx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-e2e-${{ hashFiles('frontend/**/package-lock.json', 'frontend/**/pnpm-lock.yaml', 'frontend/**/yarn.lock') }}-
-            
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: |
-          pnpm config set fetch-retries 5
-          pnpm config set fetch-retry-mintimeout 20000
-          pnpm config set fetch-retry-maxtimeout 120000
-          pnpm install --frozen-lockfile --prefer-offline
-        
-      # No need to install Playwright - it's pre-installed in the Docker image!
-        
-      - name: Build frontend for E2E
-        working-directory: ./frontend
-        env:
-          NEXT_TELEMETRY_DISABLED: 1
-        run: pnpm run build
-        
-      - name: Run E2E tests
-        working-directory: ./frontend
-        run: pnpm run test:e2e
-        
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: frontend/playwright-report/
-          retention-days: 7
+  # TEMPORARILY DISABLED - Slow CI job, not providing value during early development
+  # e2e-tests:
+  #   name: E2E Tests
+  #   runs-on: ubuntu-latest
+  #   # Wait for image build if Dockerfile changed, otherwise run immediately
+  #   needs: [changes, build-e2e-image]
+  #   if: always() && !cancelled() && !failure()
+  #   container:
+  #     # Use our custom Docker image with pre-installed Playwright and pnpm
+  #     # This saves ~45-60 seconds by not having to download and install dependencies
+  #     image: ghcr.io/${{ github.repository_owner }}/solfolio-e2e:${{ needs.changes.outputs.dockerfile == 'true' && github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+  #     credentials:
+  #       username: ${{ github.actor }}
+  #       password: ${{ secrets.GITHUB_TOKEN }}
+  #   
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #         
+  #     - name: Get pnpm store directory
+  #       shell: bash
+  #       run: |
+  #         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+  #         
+  #     - name: Setup pnpm cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: |
+  #           ${{ env.STORE_PATH }}
+  #           ~/.cache
+  #           frontend/node_modules
+  #         key: ${{ runner.os }}-pnpm-store-e2e-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-pnpm-store-e2e-
+  #           
+  #     - name: Setup Next.js build cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: |
+  #           frontend/.next/cache
+  #         key: ${{ runner.os }}-nextjs-e2e-${{ hashFiles('frontend/**/package-lock.json', 'frontend/**/pnpm-lock.yaml', 'frontend/**/yarn.lock') }}-${{ hashFiles('frontend/**.[jt]s', 'frontend/**.[jt]sx') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-nextjs-e2e-${{ hashFiles('frontend/**/package-lock.json', 'frontend/**/pnpm-lock.yaml', 'frontend/**/yarn.lock') }}-
+  #           
+  #     - name: Install frontend dependencies
+  #       working-directory: ./frontend
+  #       run: |
+  #         pnpm config set fetch-retries 5
+  #         pnpm config set fetch-retry-mintimeout 20000
+  #         pnpm config set fetch-retry-maxtimeout 120000
+  #         pnpm install --frozen-lockfile --prefer-offline
+  #       
+  #     # No need to install Playwright - it's pre-installed in the Docker image!
+  #       
+  #     - name: Build frontend for E2E
+  #       working-directory: ./frontend
+  #       env:
+  #         NEXT_TELEMETRY_DISABLED: 1
+  #       run: pnpm run build
+  #       
+  #     - name: Run E2E tests
+  #       working-directory: ./frontend
+  #       run: pnpm run test:e2e
+  #       
+  #     - name: Upload test results
+  #       if: failure()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: playwright-report
+  #         path: frontend/playwright-report/
+  #         retention-days: 7
 
   # Commented out Docker build test to save CI/CD resources
   # docker-build:


### PR DESCRIPTION
## Summary
- Temporarily disabled three slow CI jobs that are currently not providing value during early development phase
- This significantly speeds up the CI pipeline for faster iteration

## Changes Made
- Commented out `changes` job (Dockerfile change detection)
- Commented out `build-e2e-image` job (Docker image building)
- Commented out `e2e-tests` job (E2E testing)

## Rationale
These jobs are taking significant time but not providing much value at this early stage:
- E2E tests are minimal and not catching real issues yet
- Docker image building is unnecessary overhead for now
- The tests can be re-enabled once the codebase is more stable

## Impact
- CI pipeline runs ~3-5 minutes faster
- Developers can iterate more quickly
- Frontend and backend checks still run to ensure code quality

## Next Steps
Will re-enable these jobs once:
- More comprehensive E2E tests are written
- The application is closer to production readiness
- Docker deployment becomes necessary

🤖 Generated with [Claude Code](https://claude.ai/code)