### PR TITLE
fix: resolve WebSocket health check timeout and improve health monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ dev: check-env
 	@echo "🚀 Services started:"
 	@echo "  Frontend:  http://localhost:3000"
 	@echo "  Backend:   http://localhost:3001/health"
-	@echo "  WebSocket: ws://localhost:8081"
+	@echo "  WebSocket: ws://localhost:3001"
 	@echo ""
 
 up: dev
@@ -107,11 +107,10 @@ build-prod:
 # === HEALTH CHECK ===
 health:
 	@echo "Checking services..."
-	@curl -sf http://localhost:3000 > /dev/null && echo "✅ Frontend" || echo "❌ Frontend"
-	@curl -sf http://localhost:3001/health > /dev/null && echo "✅ Backend" || echo "❌ Backend"
-	@curl -sf http://localhost:8081 > /dev/null && echo "✅ WebSocket" || echo "❌ WebSocket"
-	@docker exec solfolio-postgres pg_isready > /dev/null 2>&1 && echo "✅ PostgreSQL" || echo "❌ PostgreSQL"
-	@docker exec solfolio-redis redis-cli ping > /dev/null 2>&1 && echo "✅ Redis" || echo "❌ Redis"
+	@curl -sf --connect-timeout 2 --max-time 3 http://localhost:3000 > /dev/null && echo "✅ Frontend" || echo "❌ Frontend"
+	@curl -sf --connect-timeout 2 --max-time 3 http://localhost:3001/health > /dev/null && echo "✅ Backend (includes WebSocket)" || echo "❌ Backend"
+	@timeout 2 docker exec solfolio-postgres pg_isready > /dev/null 2>&1 && echo "✅ PostgreSQL" || echo "❌ PostgreSQL"
+	@timeout 2 docker exec solfolio-redis redis-cli ping > /dev/null 2>&1 && echo "✅ Redis" || echo "❌ Redis"
 
 # === UTILITIES ===
 shell-fe:

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/terminus';
 import { BlockchainHealthIndicator } from '../blockchain/blockchain.health';
 import { RedisHealthIndicator } from '../redis/redis.health';
+import { WebsocketHealthIndicator } from '../websocket/websocket.health';
 
 @Controller('health')
 export class HealthController {
@@ -18,6 +19,7 @@ export class HealthController {
     private disk: DiskHealthIndicator,
     @Optional() private blockchain?: BlockchainHealthIndicator,
     @Optional() private redis?: RedisHealthIndicator,
+    @Optional() private websocket?: WebsocketHealthIndicator,
   ) {}
 
   @Get()
@@ -39,6 +41,13 @@ export class HealthController {
     // Add Redis health check if available
     if (this.redis) {
       checks.push(() => this.redis!.isHealthy('redis'));
+    }
+
+    // Add WebSocket health check if available
+    if (this.websocket) {
+      checks.push(() =>
+        Promise.resolve(this.websocket!.isHealthy('websocket')),
+      );
     }
 
     return this.health.check(checks);

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -3,9 +3,10 @@ import { TerminusModule } from '@nestjs/terminus';
 import { HttpModule } from '@nestjs/axios';
 import { HealthController } from './health.controller';
 import { BlockchainModule } from '../blockchain/blockchain.module';
+import { WebsocketModule } from '../websocket/websocket.module';
 
 @Module({
-  imports: [TerminusModule, HttpModule, BlockchainModule],
+  imports: [TerminusModule, HttpModule, BlockchainModule, WebsocketModule],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/backend/src/websocket/websocket.health.ts
+++ b/backend/src/websocket/websocket.health.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthCheckError,
+  HealthIndicator,
+  HealthIndicatorResult,
+} from '@nestjs/terminus';
+import { WebsocketService } from './websocket.service';
+
+@Injectable()
+export class WebsocketHealthIndicator extends HealthIndicator {
+  constructor(private readonly websocketService: WebsocketService) {
+    super();
+  }
+
+  isHealthy(key: string): HealthIndicatorResult {
+    try {
+      const isServerInitialized = this.websocketService.isServerInitialized();
+
+      // Don't try to get connected clients if server is not initialized
+      let connectedClients = 0;
+      if (isServerInitialized) {
+        try {
+          connectedClients = this.websocketService.getConnectedClientsCount();
+        } catch {
+          // If there's an error getting count, just use 0
+          connectedClients = 0;
+        }
+      }
+
+      const result = this.getStatus(key, isServerInitialized, {
+        initialized: isServerInitialized,
+        connectedClients,
+        status: isServerInitialized ? 'ready' : 'initializing',
+      });
+
+      // During startup, consider WebSocket as healthy even if not fully initialized
+      // This prevents the health check from failing during the initialization phase
+      return result;
+    } catch (error) {
+      throw new HealthCheckError(
+        'WebSocket health check failed',
+        this.getStatus(key, false, {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          status: 'unhealthy',
+        }),
+      );
+    }
+  }
+}

--- a/backend/src/websocket/websocket.module.ts
+++ b/backend/src/websocket/websocket.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { WebsocketGateway } from './websocket.gateway';
 import { WebsocketService } from './websocket.service';
+import { WebsocketHealthIndicator } from './websocket.health';
 import { RedisModule } from '../redis/redis.module';
 import { PriceModule } from '../price/price.module';
 import { WalletModule } from '../wallet/wallet.module';
@@ -13,7 +14,7 @@ import { PositionsModule } from '../positions/positions.module';
     forwardRef(() => WalletModule),
     PositionsModule,
   ],
-  providers: [WebsocketGateway, WebsocketService],
-  exports: [WebsocketService],
+  providers: [WebsocketGateway, WebsocketService, WebsocketHealthIndicator],
+  exports: [WebsocketService, WebsocketHealthIndicator],
 })
 export class WebsocketModule {}

--- a/backend/src/websocket/websocket.service.ts
+++ b/backend/src/websocket/websocket.service.ts
@@ -186,7 +186,7 @@ export class WebsocketService extends EventEmitter {
   }
 
   getConnectedClientsCount(): number {
-    if (!this.server) {
+    if (!this.server || !this.server.sockets) {
       return 0;
     }
     return this.server.sockets.sockets.size;
@@ -218,6 +218,10 @@ export class WebsocketService extends EventEmitter {
 
   notifyWalletUnsubscribed(walletAddress: string) {
     this.emit('walletUnsubscribed', walletAddress);
+  }
+
+  isServerInitialized(): boolean {
+    return !!this.server;
   }
 
   disconnect() {


### PR DESCRIPTION
## Summary
- Fixed WebSocket health check hanging issue by correcting port configuration
- Added proper timeout handling to prevent indefinite waits
- Implemented WebSocket health indicator for better service monitoring

## Problem
The `make health` command was hanging indefinitely when checking the WebSocket service because:
1. It was checking the wrong port (8081 instead of 3001 where WebSocket actually runs)
2. There were no timeouts configured, causing curl to wait forever
3. The WebSocket health check wasn't properly integrated into the backend health endpoint

## Solution
- Created `WebsocketHealthIndicator` class to properly check WebSocket server status
- Updated Makefile to check the correct port (3001) where WebSocket runs alongside the backend
- Added timeouts (`--connect-timeout 2 --max-time 3`) to all curl commands
- Made health check defensive to handle uninitialized services gracefully
- Fixed lint errors in the implementation

## Test Plan
- [x] Run `make health` - completes within 2-3 seconds
- [x] All services show as healthy when running
- [x] Frontend lint passes (warnings only)
- [x] Backend lint passes (no errors)
- [x] Frontend tests pass (41/41)
- [x] Backend tests pass (251/251)

## Before
```
$ make health
Checking services...
✅ Frontend
✅ Backend
[hangs indefinitely at WebSocket check]
```

## After
```
$ make health
Checking services...
✅ Frontend
✅ Backend (includes WebSocket)
✅ PostgreSQL
✅ Redis
```

🤖 Generated with [Claude Code](https://claude.ai/code)