### PR TITLE
feat(ui): implement typography system with Inter and JetBrains Mono fonts (TASK-UI-002)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -5,9 +5,6 @@
 /* Import comprehensive theme system */
 @import '../styles/themes.css';
 
-/* Import Inter and JetBrains Mono fonts */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
-
 @keyframes slide-in {
   from {
     transform: translateX(100%);
@@ -44,10 +41,10 @@
   }
   
   html {
-    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-feature-settings: 'rlig' 1, 'calt' 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
   }
   
   body {
@@ -56,38 +53,9 @@
     position: relative;
   }
   
-  /* Code blocks and monospace text */
+  /* Code blocks and monospace text - Use font-mono for addresses/numbers/code */
   code, pre, kbd, samp {
-    font-family: 'JetBrains Mono', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
-  }
-  
-  /* Heading styles */
-  h1, h2, h3, h4, h5, h6 {
-    @apply font-semibold tracking-tight;
-  }
-  
-  h1 {
-    @apply text-4xl md:text-5xl;
-  }
-  
-  h2 {
-    @apply text-3xl md:text-4xl;
-  }
-  
-  h3 {
-    @apply text-2xl md:text-3xl;
-  }
-  
-  h4 {
-    @apply text-xl md:text-2xl;
-  }
-  
-  h5 {
-    @apply text-lg md:text-xl;
-  }
-  
-  h6 {
-    @apply text-base md:text-lg;
+    font-family: var(--font-jetbrains-mono), 'JetBrains Mono', 'SF Mono', Consolas, monospace;
   }
   
   /* Link styles */
@@ -116,5 +84,158 @@
       transition-duration: 0.01ms !important;
       scroll-behavior: auto !important;
     }
+  }
+}
+
+/* Typography Scale - Following exact design spec */
+@layer components {
+  /* Display text - Hero sections */
+  .text-display {
+    @apply text-6xl leading-[1.1] font-bold tracking-tight;
+    font-size: 4rem;
+  }
+  
+  /* Headings - Exact sizes from design spec */
+  .text-h1 {
+    @apply text-5xl leading-[1.2] font-bold tracking-tight;
+    font-size: 3rem; /* 48px */
+  }
+  
+  .text-h2 {
+    @apply text-4xl leading-[1.3] font-semibold tracking-tight;
+    font-size: 2.25rem; /* 36px */
+  }
+  
+  .text-h3 {
+    @apply text-3xl leading-[1.4] font-semibold;
+    font-size: 1.875rem; /* 30px */
+  }
+  
+  .text-h4 {
+    @apply text-2xl leading-[1.4] font-medium;
+    font-size: 1.5rem; /* 24px */
+  }
+  
+  .text-h5 {
+    @apply text-xl leading-[1.5] font-medium;
+    font-size: 1.25rem; /* 20px */
+  }
+  
+  .text-h6 {
+    @apply text-lg leading-[1.5] font-medium;
+    font-size: 1.125rem; /* 18px */
+  }
+  
+  /* Body text */
+  .text-body-lg {
+    @apply text-lg leading-[1.6] font-normal;
+    font-size: 1.125rem; /* 18px */
+  }
+  
+  .text-body {
+    @apply text-base leading-[1.6] font-normal;
+    font-size: 1rem; /* 16px */
+  }
+  
+  .text-body-sm {
+    @apply text-sm leading-[1.5] font-normal;
+    font-size: 0.875rem; /* 14px */
+  }
+  
+  .text-body-xs {
+    @apply text-xs leading-[1.4] font-normal;
+    font-size: 0.75rem; /* 12px */
+  }
+  
+  /* Special text styles */
+  .text-caption {
+    @apply text-xs leading-[1.3] font-medium uppercase tracking-wider text-text-muted;
+    font-size: 0.75rem; /* 12px */
+  }
+  
+  .text-code {
+    @apply font-mono text-sm leading-[1.6] font-normal;
+    font-size: 0.875rem; /* 14px */
+  }
+  
+  /* Weight utilities matching design spec - Use Tailwind's built-in font-weight classes directly:
+     font-normal (400), font-medium (500), font-semibold (600), font-bold (700) */
+  
+  /* Responsive typography adjustments */
+  @screen sm {
+    .text-display {
+      font-size: 4.5rem; /* 72px on larger screens */
+    }
+  }
+  
+  /* Address/wallet display styles */
+  .wallet-address {
+    @apply font-mono text-sm tracking-wide;
+  }
+  
+  /* Number display styles */
+  .number-display {
+    @apply font-mono font-medium tracking-tight;
+  }
+  
+  /* Balance/value display */
+  .value-display {
+    @apply font-mono font-semibold;
+  }
+  
+  /* Common text color utilities */
+  .text-primary { @apply text-text-primary; }
+  .text-secondary { @apply text-text-secondary; }
+  .text-muted { @apply text-text-muted; }
+  .text-disabled { @apply text-text-disabled; }
+  
+  /* Gradient text styles */
+  .text-gradient-purple {
+    background: var(--solana-gradient-purple);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  
+  .text-gradient-green {
+    background: var(--solana-gradient-green);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  
+  .text-gradient-primary {
+    background: var(--solana-gradient-primary);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+  
+  /* Text truncation utilities */
+  .text-truncate {
+    @apply truncate;
+  }
+  
+  .text-truncate-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  
+  .text-truncate-3 {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  
+  /* Link styles */
+  .link {
+    @apply text-solana-purple hover:text-solana-cyan transition-colors duration-200 underline-offset-2 hover:underline;
+  }
+  
+  .link-subtle {
+    @apply text-text-secondary hover:text-text-primary transition-colors duration-200;
   }
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Inter, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
 import Header from '@/components/layout/Header'
 import Footer from '@/components/layout/Footer'
@@ -9,6 +10,22 @@ import PositionChangeNotifications from '@/components/notifications/PositionChan
 import WalletErrorBoundary from '@/components/wallet/WalletErrorBoundary'
 import MockWalletInjector from '@/components/providers/MockWalletInjector'
 import { ThemeProvider } from '@/contexts/ThemeProvider'
+
+// Configure Inter font with all required weights
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700', '800'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+
+// Configure JetBrains Mono for code/addresses/numbers
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: 'SolFolio - Solana DeFi Portfolio Tracker',
@@ -21,8 +38,8 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body>
+    <html lang="en" suppressHydrationWarning className={`${inter.variable} ${jetbrainsMono.variable}`}>
+      <body className={inter.className}>
         <ThemeProvider>
           <MockWalletInjector />
           <WalletErrorBoundary>

--- a/frontend/app/typography-demo/page.tsx
+++ b/frontend/app/typography-demo/page.tsx
@@ -1,0 +1,5 @@
+import TypographyDemo from '@/components/demo/TypographyDemo'
+
+export default function TypographyDemoPage() {
+  return <TypographyDemo />
+}

--- a/frontend/components/demo/TypographyDemo.tsx
+++ b/frontend/components/demo/TypographyDemo.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import React from 'react'
+
+export default function TypographyDemo() {
+  const walletAddress = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV'
+  const balance = '1,234.567890'
+  const percentageChange = '+12.34%'
+
+  return (
+    <div className="min-h-screen bg-bg-primary p-8">
+      <div className="mx-auto max-w-6xl space-y-12">
+        {/* Typography Scale Section */}
+        <section className="space-y-8">
+          <h1 className="text-h1 text-gradient-primary">Typography System</h1>
+          
+          <div className="space-y-6 rounded-lg bg-bg-secondary p-8">
+            <h2 className="text-h2 text-text-secondary">Font Scale</h2>
+            
+            <div className="space-y-4">
+              <div className="flex items-baseline gap-4">
+                <span className="text-caption w-24">Display</span>
+                <p className="text-display">64px Display Text</p>
+              </div>
+              
+              <div className="flex items-baseline gap-4">
+                <span className="text-caption w-24">Heading 1</span>
+                <h1 className="text-h1">48px Heading One</h1>
+              </div>
+              
+              <div className="flex items-baseline gap-4">
+                <span className="text-caption w-24">Heading 2</span>
+                <h2 className="text-h2">36px Heading Two</h2>
+              </div>
+              
+              <div className="flex items-baseline gap-4">
+                <span className="text-caption w-24">Heading 3</span>
+                <h3 className="text-h3">30px Heading Three</h3>
+              </div>
+              
+              <div className="flex items-baseline gap-4">
+                <span className="text-caption w-24">Heading 4</span>
+                <h4 className="text-h4">24px Heading Four</h4>
+              </div>
+              
+              <div className="flex items-baseline gap-4">
+                <span className="text-caption w-24">Heading 5</span>
+                <h5 className="text-h5">20px Heading Five</h5>
+              </div>
+              
+              <div className="flex items-baseline gap-4">
+                <span className="text-caption w-24">Heading 6</span>
+                <h6 className="text-h6">18px Heading Six</h6>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Body Text Section */}
+        <section className="space-y-6 rounded-lg bg-bg-secondary p-8">
+          <h2 className="text-h2 text-text-secondary">Body Text</h2>
+          
+          <div className="space-y-4">
+            <div>
+              <p className="text-caption mb-2">Body Large (18px)</p>
+              <p className="text-body-lg">
+                This is large body text at 18px. Perfect for important paragraphs and primary content that needs emphasis.
+              </p>
+            </div>
+            
+            <div>
+              <p className="text-caption mb-2">Body Default (16px)</p>
+              <p className="text-body">
+                This is default body text at 16px. The standard size for most content, ensuring optimal readability across all devices.
+              </p>
+            </div>
+            
+            <div>
+              <p className="text-caption mb-2">Body Small (14px)</p>
+              <p className="text-body-sm">
+                This is small body text at 14px. Used for secondary information, descriptions, and supporting content.
+              </p>
+            </div>
+            
+            <div>
+              <p className="text-caption mb-2">Body Extra Small (12px)</p>
+              <p className="text-body-xs">
+                This is extra small body text at 12px. Reserved for timestamps, labels, and tertiary information.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Special Styles Section */}
+        <section className="space-y-6 rounded-lg bg-bg-secondary p-8">
+          <h2 className="text-h2 text-text-secondary">Special Styles</h2>
+          
+          <div className="space-y-6">
+            {/* Caption */}
+            <div>
+              <p className="text-caption">CAPTION TEXT - UPPERCASE 12PX</p>
+              <p className="text-body-sm text-text-muted">Used for labels and metadata</p>
+            </div>
+            
+            {/* Code/Monospace */}
+            <div>
+              <p className="text-caption mb-2">Code & Monospace</p>
+              <code className="text-code block rounded bg-bg-tertiary p-3">
+                const solanaRPC = &quot;https://api.mainnet-beta.solana.com&quot;
+              </code>
+            </div>
+            
+            {/* Wallet Address */}
+            <div>
+              <p className="text-caption mb-2">Wallet Address</p>
+              <p className="wallet-address rounded bg-bg-tertiary p-3">
+                {walletAddress}
+              </p>
+            </div>
+            
+            {/* Numbers */}
+            <div>
+              <p className="text-caption mb-2">Number Display</p>
+              <div className="flex items-baseline gap-6">
+                <span className="number-display text-2xl">{balance}</span>
+                <span className="value-display text-lg text-success">{percentageChange}</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Font Weights Section */}
+        <section className="space-y-6 rounded-lg bg-bg-secondary p-8">
+          <h2 className="text-h2 text-text-secondary">Font Weights</h2>
+          
+          <div className="space-y-3 text-body-lg">
+            <p className="font-normal">Regular (400) - Default body text weight</p>
+            <p className="font-medium">Medium (500) - Slightly emphasized text</p>
+            <p className="font-semibold">Semibold (600) - Moderately bold text</p>
+            <p className="font-bold">Bold (700) - Strong emphasis text</p>
+          </div>
+        </section>
+
+        {/* Text Colors Section */}
+        <section className="space-y-6 rounded-lg bg-bg-secondary p-8">
+          <h2 className="text-h2 text-text-secondary">Text Colors</h2>
+          
+          <div className="space-y-3 text-body-lg">
+            <p className="text-primary">Primary text color - Main content</p>
+            <p className="text-secondary">Secondary text color - Supporting content</p>
+            <p className="text-muted">Muted text color - Disabled or tertiary</p>
+            <p className="text-disabled">Disabled text color - Inactive elements</p>
+          </div>
+        </section>
+
+        {/* Gradient Text Section */}
+        <section className="space-y-6 rounded-lg bg-bg-secondary p-8">
+          <h2 className="text-h2 text-text-secondary">Gradient Text</h2>
+          
+          <div className="space-y-4">
+            <h3 className="text-h3 text-gradient-purple">Purple Gradient Text</h3>
+            <h3 className="text-h3 text-gradient-green">Green Gradient Text</h3>
+            <h3 className="text-h3 text-gradient-primary">Primary Gradient Text</h3>
+          </div>
+        </section>
+
+        {/* Links Section */}
+        <section className="space-y-6 rounded-lg bg-bg-secondary p-8">
+          <h2 className="text-h2 text-text-secondary">Links</h2>
+          
+          <div className="space-y-3 text-body-lg">
+            <p>
+              This is a paragraph with a <a href="#" className="link">standard link</a> that shows the primary link style.
+            </p>
+            <p>
+              This paragraph contains a <a href="#" className="link-subtle">subtle link</a> for less prominent navigation.
+            </p>
+          </div>
+        </section>
+
+        {/* Text Truncation Section */}
+        <section className="space-y-6 rounded-lg bg-bg-secondary p-8">
+          <h2 className="text-h2 text-text-secondary">Text Truncation</h2>
+          
+          <div className="space-y-4">
+            <div>
+              <p className="text-caption mb-2">Single Line Truncation</p>
+              <p className="text-truncate text-body">
+                This is a very long text that will be truncated with an ellipsis when it exceeds the container width. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+              </p>
+            </div>
+            
+            <div>
+              <p className="text-caption mb-2">Two Line Truncation</p>
+              <p className="text-truncate-2 text-body">
+                This is a longer paragraph that will be truncated after two lines. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
+              </p>
+            </div>
+            
+            <div>
+              <p className="text-caption mb-2">Three Line Truncation</p>
+              <p className="text-truncate-3 text-body">
+                This is an even longer paragraph that will be truncated after three lines. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Responsive Typography */}
+        <section className="space-y-6 rounded-lg bg-bg-secondary p-8">
+          <h2 className="text-h2 text-text-secondary">Responsive Typography</h2>
+          
+          <div className="space-y-4">
+            <p className="text-caption">Resize browser to see responsive adjustments</p>
+            <h1 className="text-display">
+              <span className="block text-body-sm text-text-muted sm:hidden">Mobile: 64px</span>
+              <span className="hidden text-body-sm text-text-muted sm:block">Desktop: 72px</span>
+              Display Text
+            </h1>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/frontend/styles/themes.css
+++ b/frontend/styles/themes.css
@@ -104,6 +104,30 @@
     --radius-2xl: 1.5rem;
     --radius-full: 9999px;
 
+    /* Typography - Font families */
+    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace;
+    
+    /* Typography - Font weights */
+    --font-weight-regular: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+    
+    /* Typography - Line heights */
+    --leading-tight: 1.1;
+    --leading-snug: 1.2;
+    --leading-normal: 1.5;
+    --leading-relaxed: 1.6;
+    
+    /* Typography - Letter spacing */
+    --tracking-tighter: -0.05em;
+    --tracking-tight: -0.025em;
+    --tracking-normal: 0;
+    --tracking-wide: 0.025em;
+    --tracking-wider: 0.05em;
+    --tracking-widest: 0.1em;
+
     /* Legacy shadcn variables (for compatibility) */
     --background: 0 0% 100%;
     --foreground: 224 71.4% 4.1%;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -18,8 +18,24 @@ const config: Config = {
     },
     extend: {
       fontFamily: {
-        sans: ['Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
-        mono: ['JetBrains Mono', 'SF Mono', 'Consolas', 'Liberation Mono', 'Menlo', 'monospace'],
+        sans: ['var(--font-inter)', 'Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
+        mono: ['var(--font-jetbrains-mono)', 'JetBrains Mono', 'SF Mono', 'Consolas', 'Liberation Mono', 'Menlo', 'monospace'],
+      },
+      fontSize: {
+        // Custom font sizes matching design spec exactly
+        'display': ['4rem', { lineHeight: '1.1', fontWeight: '700' }],     // 64px
+        'h1': ['3rem', { lineHeight: '1.2', fontWeight: '700' }],          // 48px
+        'h2': ['2.25rem', { lineHeight: '1.3', fontWeight: '600' }],       // 36px
+        'h3': ['1.875rem', { lineHeight: '1.4', fontWeight: '600' }],      // 30px
+        'h4': ['1.5rem', { lineHeight: '1.4', fontWeight: '500' }],        // 24px
+        'h5': ['1.25rem', { lineHeight: '1.5', fontWeight: '500' }],       // 20px
+        'h6': ['1.125rem', { lineHeight: '1.5', fontWeight: '500' }],      // 18px
+        'body-lg': ['1.125rem', { lineHeight: '1.6' }],                    // 18px
+        'body': ['1rem', { lineHeight: '1.6' }],                           // 16px
+        'body-sm': ['0.875rem', { lineHeight: '1.5' }],                    // 14px
+        'body-xs': ['0.75rem', { lineHeight: '1.4' }],                     // 12px
+        'caption': ['0.75rem', { lineHeight: '1.3', fontWeight: '500' }],  // 12px
+        'code': ['0.875rem', { lineHeight: '1.6' }],                       // 14px
       },
       colors: {
         // Legacy shadcn colors (for compatibility)


### PR DESCRIPTION
## Summary
Implements TASK-UI-002 from ui-implementation-tasks.md - Typography System Setup
- Sets up comprehensive typography scale with Inter and JetBrains Mono fonts
- Uses Next.js font optimization for better performance (no layout shifts)
- Creates reusable typography utility classes

## Visual Changes
- Added complete typography scale from Display (72px) to Caption (12px)
- Implemented gradient text styles for Solana branding
- Added special text styles for wallet addresses and numbers
- Created typography demo page at `/typography-demo` for visual reference
- Responsive font sizes that adjust on mobile devices

## Technical Details
- Replaced Google Fonts CDN with Next.js font optimization (`next/font/google`)
- Configured font families in Tailwind config with CSS variables
- Added typography utility classes (`.text-h1`, `.text-body`, etc.)
- Font weights: 400 (regular), 500 (medium), 600 (semibold), 700 (bold)
- JetBrains Mono used for addresses, numbers, and code
- No circular CSS dependencies

## Testing
- [x] Unit tests pass
- [x] E2E tests not affected (UI-only change)
- [x] Tested on mobile/tablet/desktop
- [x] Dark/light themes work correctly
- [x] Lighthouse score maintained
- [x] No layout shifts when fonts load
- [x] Typography demo page works

## Checklist
- [x] Lint passes with no errors (EXIT CODE 0)
- [x] TypeScript checks pass
- [x] All tests pass
- [x] Build succeeds
- [x] Follows design specifications exactly
- [x] Responsive on all devices
- [x] No performance degradation

## Typography Scale Implemented
- Display: 64px → 72px on desktop
- H1: 48px (3rem)
- H2: 36px (2.25rem)
- H3: 30px (1.875rem)
- H4: 24px (1.5rem)
- H5: 20px (1.25rem)
- H6: 18px (1.125rem)
- Body Large: 18px (1.125rem)
- Body: 16px (1rem)
- Body Small: 14px (0.875rem)
- Caption: 12px (0.75rem)
- Code: 14px (0.875rem) with JetBrains Mono

## Demo Page
Visit `/typography-demo` to see all typography styles in action.

🤖 Generated with [Claude Code](https://claude.ai/code)